### PR TITLE
Fix type signature for pipeline_setup.configure

### DIFF
--- a/form_observability/pipeline_setup.py
+++ b/form_observability/pipeline_setup.py
@@ -8,6 +8,7 @@ pipeline_setup.configure(
 )
 """
 import os
+from typing import Dict, Optional
 
 import opentelemetry
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
@@ -21,7 +22,7 @@ from opentelemetry.sdk.trace import TracerProvider, SpanLimits
 
 def configure(
     service_name: str,
-    otlp_headers: str,
+    otlp_headers: Optional[Dict[str, str]],
     otlp_endpoint: str = "https://api.honeycomb.io",
     instrument_requests: bool = False,
 ) -> None:


### PR DESCRIPTION
As seen here: https://github.com/open-telemetry/opentelemetry-python/blob/b9f31e91a8263bc8effc9abce889d438927d47ec/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py#L78