### PR TITLE
update dependency version

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This library is provided under the MIT license, see [LICENSE](LICENSE).
 
 ## Release Notes
 
+*   0.3.2 Update `grpcio` minimum dependency version to 1.48.1 and `dagster` to 1.50.0.
 *   0.3.1 Fix type used for `otlp_headers` to be a `dict`. Thanks @spenczar !
 *   0.3.0 Add `ContextAwareTracer.start_new_linked_trace`.
 *   0.2.0 Switch to `context.op_handle` and `materialization.metadata` as dict for Dagster 1.2.

--- a/form_observability/__init__.py
+++ b/form_observability/__init__.py
@@ -4,7 +4,7 @@
 #: *   Major: breaking API changes, significant feature additions.
 #: *   Minor: standard feature additions and improvements. No breaking changes.
 #: *   Micro: small bug fixes.
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 # Make commonly used symbols importable from form_observability.
 from .context_aware import ContextAwareTracer, ctx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,12 @@ dependencies = [
     # Dagster and OTel. This specifies the versions to match Dagster 1.1.7, which
     # also satisfy OTel. (If pip picks OTel's version first, it's outside
     # Dagster's bounds.)
-    "grpcio>=1.32.0,<1.48.1",
+    "grpcio>=1.48.1",
     "packaging>=20.9,<22",
     # Accept any version that's not a major version upgrade, but is at least
     # a known good recent version. This is slightly different from for example
     # ~=1.1.6 which would mean >=1.1.6,<1.2 and is too strict.
-    "dagster>=1.2.0,<2",
+    "dagster>=1.5.0,<2",
     "opentelemetry-api>=1.15.0,<2",
     "opentelemetry-sdk>=1.15.0,<2",
     "opentelemetry-exporter-otlp-proto-grpc>=1.15.0,<2",
@@ -35,7 +35,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "pytest~=6.1.2",
+    "pytest~=6.2.5",
     "pytest-html~=2.1.1",
     "pre-commit==2.15.0",
 ]


### PR DESCRIPTION
Restricting `grpcio` to be lower than `1.48.1` can cause some impossible dependency resolve, such as with `databricks-connect 13.3.3` which depends on `grpcio>=1.48.1`.